### PR TITLE
Fix struct read via XbusStreamReader

### DIFF
--- a/xbus/XbusStreamReader.h
+++ b/xbus/XbusStreamReader.h
@@ -199,37 +199,29 @@ void XbusStreamReader::_get_data(_T &src, _Tout &data)
 template<typename _T>
 void XbusStreamReader::read(_T &data)
 {
-    if ((_pos + sizeof(_T)) > _size) {
+    const auto dsize = sizeof(_T);
+
+    if ((_pos + dsize) > _size) {
         _pos = _size;
         data = {};
         return;
     }
 
-    switch (sizeof(_T)) {
-    case 1:
+    if constexpr (dsize == 1) {
         data = static_cast<_T>(_buf[_pos]);
-        break;
-
-    case 2:
+    } else if constexpr (dsize == 2) {
         uint16_t data_le16;
         _get_data(data_le16, data);
-        break;
-
-    case 4:
+    } else if constexpr (dsize == 4) {
         uint32_t data_le32;
         _get_data(data_le32, data);
-        break;
-
-    case 8:
+    } else if constexpr (dsize == 8) {
         uint64_t data_le64;
         _get_data(data_le64, data);
-        break;
-
-    default:
+    } else {
         // support struct with fixed size
         // i.e. stream >> struct{uint32_t a; uint16_t b;};
-        memcpy(&data, &_buf[_pos], sizeof(_T));
-        break;
+        memcpy(&data, &_buf[_pos], dsize);
     }
-    _pos += sizeof(_T);
+    _pos += dsize;
 }


### PR DESCRIPTION
It's impossible now to read struct via XbusStreamReader. F.ex.:
```
XbusStreamReader stream(...);
mandala::bundle::swarm_s swarm;
stream.read(swarm);
```
Generate error:
```
../subprojects/apx-lib/xbus/XbusStreamReader.h:210:16: error: no matching function for call to ‘mandala::bundle::swarm_s::swarm_s(const uint8_t&)’
  210 |         data = static_cast<_T>(_buf[_pos]);
```

But `default` switch in this method suppose that it should be works.
This PR add `constexpr` check argument size and fix this error.